### PR TITLE
doc: add scanner option to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ steps:
       only-rule: 'ruby_lang_cookies,ruby_lang_http_post_insecure_with_data'
       skip-path: 'users/*.go,users/admin.sql'
 ```
+
 ### Full Reporting Example
 
 ```yaml
@@ -55,9 +56,14 @@ jobs:
             const passed = `${{ steps.report.outputs.exit_code }}` == "0";
             if(!passed){ core.setFailed(report); }
 ```
+
 you can see this workflow in action on our [demo repo](https://github.com/Bearer/bear-publishing/actions/workflows/bearer.yml)
 
 ## Inputs
+
+### `scanner`
+
+**Optional** Specify the comma-separated scanner to use e.g. `sast,secrets`
 
 ### `config-file`
 

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ branding:
   icon: "check-square"
   color: "purple"
 inputs:
+  scanner:
+    description: "Specify the comma separated scanners e.g. --scanner secrets,sast"
+    required: false
+    default: "sast"
   config-file:
     description: "configuration file path"
     required: false
@@ -33,6 +37,7 @@ runs:
   using: "docker"
   image: "Dockerfile"
   args:
+    - "--scanner=${{ inputs.scanner }}"
     - "--config-file=${{ inputs.config-file }}"
     - "--only-rule=${{ inputs.only-rule }}"
     - "--skip-rule=${{ inputs.skip-rule }}"


### PR DESCRIPTION
references https://github.com/Bearer/bearer/issues/679

Add references to the new scanner options which allows `sast` and `secrets` to be ran separately