### PR TITLE
fix: filter out empty arguments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   scanner:
     description: "Specify the comma separated scanners e.g. --scanner secrets,sast"
     required: false
-    default: "sast"
+    default: ""
   config-file:
     description: "configuration file path"
     required: false
@@ -27,7 +27,7 @@ inputs:
   severity:
     description: "Specify which severities are included in the report as a comma separated string"
     required: false
-    default: "critical,high,medium,low,warning"
+    default: ""
 outputs:
   rule_breaches:
     description: "Details of any rule breaches that occur"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/sh -l
 
-RULE_BREACHES=`bearer scan --quiet $* .`
+# Filter out any empty args
+args=($@)
+given_args=($(for i in ${args[@]}
+    do echo $i
+done | grep =.))
+
+RULE_BREACHES=`bearer scan --quiet ${given_args[@]} .`
 SCAN_EXIT_CODE=$?
 
 echo "::debug::$RULE_BREACHES"


### PR DESCRIPTION
In the entrypoint we were running the command with all given arguments this meant that in some cases behavior would be overridden unintentionally.

This was most a problem with --only-rule= --skip-rule= overriding conifg file settings