### PR TITLE
feat: pin version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bearer/bearer:latest-amd64
+FROM ghcr.io/bearer/bearer:v1.3.1-amd64
 COPY entrypoint.sh /entrypoint.sh
 USER root
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Pin the version of the docker image so we can tag the action with the same version and allow users to choose the version they are using.

Closes https://github.com/Bearer/bearer-action/issues/18