### PR TITLE
fix: update entrypoint to match new base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bearer/bearer:v1.3.1-amd64
+FROM ghcr.io/bearer/bearer:latest-amd64
 COPY entrypoint.sh /entrypoint.sh
 USER root
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -l
+#!/bin/bash
 
 # Filter out any empty args
 args=$(for var in "$@"; do echo "$var";done | grep =.)


### PR DESCRIPTION
Make the entrypoint script compatible with the latest image and unpin the image version.

The base image now uses Ubuntu and the current entrypoint was incompatible.