### PR TITLE
feat: allow version to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ you can see this workflow in action on our [demo repo](https://github.com/Bearer
 
 ## Inputs
 
+### `version`
+
+**Optional** Specify the Bearer version to use. This must match a Bearer release name.
+
 ### `scanner`
 
 **Optional** Specify the comma-separated scanner to use e.g. `sast,secrets`

--- a/action.yml
+++ b/action.yml
@@ -44,9 +44,11 @@ runs:
       shell: bash
       run: |
         VERSION="${{ inputs.version }}"
-        VERSION="${VERSION#v}"
+        if [[ ! -z "$VERSION" ]]; then
+          VERSION="v${VERSION#v}"
+        fi
 
-        curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh -s -- -b "$RUNNER_TEMP" "v$VERSION"
+        curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh -s -- -b "$RUNNER_TEMP" "$VERSION"
     - name: Run
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ branding:
   icon: "check-square"
   color: "purple"
 inputs:
+  version:
+    description: "Specify the Bearer version to use. This must match a Bearer release name."
+    required: false
+    default: ""
   scanner:
     description: "Specify the comma separated scanners e.g. --scanner secrets,sast"
     required: false
@@ -34,12 +38,22 @@ outputs:
   exit_code:
     description: "exit code from binary"
 runs:
-  using: "docker"
-  image: "Dockerfile"
-  args:
-    - "--scanner=${{ inputs.scanner }}"
-    - "--config-file=${{ inputs.config-file }}"
-    - "--only-rule=${{ inputs.only-rule }}"
-    - "--skip-rule=${{ inputs.skip-rule }}"
-    - "--skip-path=${{ inputs.skip-path }}"
-    - "--severity=${{ inputs.severity }}"
+  using: "composite"
+  steps:
+    - name: Install
+      shell: bash
+      run: |
+        VERSION="${{ inputs.version }}"
+        VERSION="${VERSION#v}"
+
+        curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh -s -- -b "$RUNNER_TEMP" "v$VERSION"
+    - name: Run
+      shell: bash
+      run: |
+        $GITHUB_ACTION_PATH/entrypoint.sh \
+          "--scanner=${{ inputs.scanner }}" \
+          "--config-file=${{ inputs.config-file }}" \
+          "--only-rule=${{ inputs.only-rule }}" \
+          "--skip-rule=${{ inputs.skip-rule }}" \
+          "--skip-path=${{ inputs.skip-path }}" \
+          "--severity=${{ inputs.severity }}"

--- a/action.yml
+++ b/action.yml
@@ -35,13 +35,14 @@ inputs:
 outputs:
   rule_breaches:
     description: "Details of any rule breaches that occur"
+    value: ${{ steps.run.outputs.rule_breaches }}
   exit_code:
     description: "exit code from binary"
+    value: ${{ steps.run.outputs.exit_code }}
 runs:
   using: "composite"
   steps:
-    - name: Install
-      shell: bash
+    - shell: bash
       run: |
         VERSION="${{ inputs.version }}"
         if [[ ! -z "$VERSION" ]]; then
@@ -49,7 +50,7 @@ runs:
         fi
 
         curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh -s -- -b "$RUNNER_TEMP" "$VERSION"
-    - name: Run
+    - id: run
       shell: bash
       run: |
         $GITHUB_ACTION_PATH/entrypoint.sh \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 # Filter out any empty args
 args=$(for var in "$@"; do echo "$var";done | grep =.)
 
-RULE_BREACHES=`bearer scan --quiet ${args//$'\n'/ } .`
+RULE_BREACHES=`$RUNNER_TEMP/bearer scan --quiet ${args//$'\n'/ } .`
 SCAN_EXIT_CODE=$?
 
 echo "::debug::$RULE_BREACHES"


### PR DESCRIPTION
Allows a version to be specified as an input to the action. This version must match a release name, with or without the `v` prefix. eg. `1.4.0` or `v1.4.0` are both acceptable values. 

By default we continue to use the latest version.

To support this change, we switch to downloading the executable and running it under the Github runner, rather than using the docker image.

We probably should make this a nodejs action and use Github's libraries for downloading/caching. But I didn't want to take on too big a change.