### PR TITLE
feat: add support for bearer cloud api key

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: "Specify which format to use for the report (json, yaml)"
     required: false
     default: ""
+  api-key:
+    description: "For use with Bearer Cloud"
+    required: false
+    default: ""
 outputs:
   rule_breaches:
     description: "Details of any rule breaches that occur"
@@ -64,4 +68,5 @@ runs:
           "--skip-rule=${{ inputs.skip-rule }}" \
           "--skip-path=${{ inputs.skip-path }}" \
           "--format=${{ inputs.format }}" \
-          "--severity=${{ inputs.severity }}"
+          "--severity=${{ inputs.severity }}" \
+          "--api-key=${{ inputs.api-key }}"


### PR DESCRIPTION
Add support for using api keys to send data to bearer cloud as added here https://github.com/Bearer/bearer/pull/814