### PR TITLE
fix: pass in information from context

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,10 @@ runs:
         curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh -s -- -b "$RUNNER_TEMP" "$VERSION"
     - id: run
       shell: bash
+      env:
+        SHA: ${{ github.event.after }}
+        CURRENT_BRANCH: ${{ github.head_ref }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       run: |
         $GITHUB_ACTION_PATH/entrypoint.sh \
           "--scanner=${{ inputs.scanner }}" \


### PR DESCRIPTION
Pass in information to the binary thats not able to be captured using git commands due to how checkout works.

companion change in bearer/bearer here: https://github.com/Bearer/bearer/pull/1009 