### PR TITLE
feat: diff scanning for PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ jobs:
           diff: true
 ```
 
-See our guide on [configuring a scan](/guides/configure-scan#only-report-new-findings-on-a-branch)
+See our guide on [configuring a scan](https://docs.bearer.com/guides/configure-scan#only-report-new-findings-on-a-branch)
 for more information on differential scans.
 
 ### Using [Reviewdog](https://github.com/Reviewdog/Reviewdog) for PR review comments with Bearer

--- a/README.md
+++ b/README.md
@@ -50,6 +50,38 @@ jobs:
 
 you can see this workflow in action on our [demo repo](https://github.com/Bearer/bear-publishing/actions/workflows/bearer.yml)
 
+### Pull Request Diff
+
+When the Bearer action is being used to check a pull request, you can tell the
+action to only report findings introduced within the pull request by setting
+the `diff` input parameter to `true`.
+
+```yaml
+name: Bearer PR Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  rule_check:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Report
+        id: report
+        uses: bearer/bearer-action@v2
+        with:
+          diff: true
+```
+
+See our guide on [configuring a scan](/guides/configure-scan#only-report-new-findings-on-a-branch)
+for more information on differential scans.
+
 ### Using [Reviewdog](https://github.com/Reviewdog/Reviewdog) for PR review comments with Bearer
 
 ```yaml
@@ -74,6 +106,7 @@ jobs:
         with:
           format: rdjson
           output: rd.json
+          diff: true
       - uses: reviewdog/action-setup@v1
         with:
           reviewdog_version: latest

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   rule_check:
@@ -112,11 +113,10 @@ jobs:
           reviewdog_version: latest
       - name: Run reviewdog
         env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.REVIEWDOG_GITHUB_API_TOKEN }}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cat rd.json | reviewdog -f=rdjson -reporter=github-pr-review
 ```
-Remember to setup a personal access [token](https://github.com/settings/personal-access-tokens/new) with PR read and write permissions and save it to your repo secrets as `REVIEWDOG_GITHUB_API_TOKEN` and you should be good to go.
 
 ### Using [Defect Dojo](https://github.com/DefectDojo/django-DefectDojo) to monitor findings
 

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: "For use with Bearer Cloud"
     required: false
     default: ""
+  diff:
+    description: "Enable differential scanning. Only supported for pull request events"
+    required: false
+    default: "false"
 outputs:
   rule_breaches:
     description: "Details of any rule breaches that occur"
@@ -71,7 +75,9 @@ runs:
       env:
         SHA: ${{ github.event.pull_request.head.sha }}
         CURRENT_BRANCH: ${{ github.head_ref }}
+        DIFF_BASE_BRANCH: ${{ fromJSON(inputs.diff) && github.base_ref || '' }}
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         $GITHUB_ACTION_PATH/entrypoint.sh \
           "--scanner=${{ inputs.scanner }}" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,12 +8,11 @@ SCAN_EXIT_CODE=$?
 
 echo "::debug::$RULE_BREACHES"
 
-# Convert to single line
-RULE_BREACHES="${RULE_BREACHES//'%'/%25}"
-RULE_BREACHES="${RULE_BREACHES//$'\n'/%0A}"
-RULE_BREACHES="${RULE_BREACHES//$'\r'/%0D}"
+EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
 
-echo "rule_breaches=$RULE_BREACHES" >> $GITHUB_OUTPUT
+echo "rule_breaches<<$EOF" >> $GITHUB_OUTPUT
+echo "$RULE_BREACHES" >> $GITHUB_OUTPUT
+echo "$EOF" >> $GITHUB_OUTPUT
 
 echo "exit_code=$SCAN_EXIT_CODE" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Adds support for a `diff` boolean input that only reports findings added in a PR.

Also:
- Changes the output to use the multiline/heredoc syntax instead of URL encoding the output. During testing, output was encountered that wasn't encoded properly.
- Simplifies reviewdog instructions by using the github actions token (with added pull request permissions).

Corresponding changes to the docs website are in https://github.com/Bearer/bearer/pull/1169.