### PR TITLE
feat: remove hard-coded quiet flag and hide progress bar by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,10 @@ inputs:
     description: "Enable differential scanning. Only supported for pull request events"
     required: false
     default: "false"
+  quiet:
+    description: "Suppress non-essential messages"
+    required: false
+    default: "false"
   exit-code:
     description: "Forces the exit-code when errors are reported"
     required: false
@@ -99,4 +103,5 @@ runs:
           "--output=${{ inputs.output }}" \
           "--exit-code=${{ inputs.exit-code }}" \
           "--severity=${{ inputs.severity }}" \
-          "--api-key=${{ inputs.api-key }}"
+          "--api-key=${{ inputs.api-key }}" \
+          "--quiet=${{ inputs.quiet }}"

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,11 @@ inputs:
   quiet:
     description: "Suppress non-essential messages"
     required: false
-    default: "false"
+    default: ""
+  hide-progress-bar:
+    description: "Hide progress bar from output"
+    required: false
+    default: "true"
   exit-code:
     description: "Forces the exit-code when errors are reported"
     required: false
@@ -104,4 +108,5 @@ runs:
           "--exit-code=${{ inputs.exit-code }}" \
           "--severity=${{ inputs.severity }}" \
           "--api-key=${{ inputs.api-key }}" \
-          "--quiet=${{ inputs.quiet }}"
+          "--quiet=${{ inputs.quiet }}" \
+          "--hide-progress-bar=${{ inputs.hide-progress-bar }}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 # Filter out any empty args
 args=$(for var in "$@"; do echo "$var";done | grep =.)
 
-RULE_BREACHES=`$RUNNER_TEMP/bearer scan --hide-progress-bar ${args//$'\n'/ } .`
+RULE_BREACHES=`$RUNNER_TEMP/bearer scan ${args//$'\n'/ } .`
 SCAN_EXIT_CODE=$?
 
 echo "::debug::$RULE_BREACHES"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 # Filter out any empty args
 args=$(for var in "$@"; do echo "$var";done | grep =.)
 
-RULE_BREACHES=`$RUNNER_TEMP/bearer scan --quiet ${args//$'\n'/ } .`
+RULE_BREACHES=`$RUNNER_TEMP/bearer scan --hide-progress-bar ${args//$'\n'/ } .`
 SCAN_EXIT_CODE=$?
 
 echo "::debug::$RULE_BREACHES"


### PR DESCRIPTION
Remove hard-coded `--quiet` flag from entrypoint.sh 
Add `hide-progress-bar` flag with default set to true
Add `quiet` flag with no default (will be removed from args list)

Closes #48