### PR TITLE
chore: ensure git is installed as a dependency

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,15 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - id: check_git_installed
+      shell: bash
+      run: |
+        if git --version &> /dev/null; then
+          echo "Git is installed. Version: $(git --version)"
+        else
+          echo "Git is not installed on this system."
+          exit 1
+        fi
     - shell: bash
       run: |
         VERSION="${{ inputs.version }}"


### PR DESCRIPTION
Test Git is installed and available before trying to install Bearer

<img width="371" alt="image" src="https://github.com/Bearer/bearer-action/assets/110196/48edc878-50d1-42f8-85ea-688d571ec68f">

<img width="405" alt="image" src="https://github.com/Bearer/bearer-action/assets/110196/5a68660e-a230-4eab-be5f-8f1154997320">

Related to https://github.com/Bearer/bearer/issues/1411
